### PR TITLE
adding changes for upload download minio

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 
 on:
   pull_request:
-    types: [opened]
+    types: [closed, synchronize, reopened, opened]
     branches: ["*"]
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
+local_test.py
 # poetry lock
 *.lock
 

--- a/docs/source/guides/minio_read_write.rst
+++ b/docs/source/guides/minio_read_write.rst
@@ -63,3 +63,11 @@ or write:
     minio_client.write_file(file_path="/my_file/path/to/file.csv", output_data=large_df, file_type="csv")
 
 
+or upload / download a file to / from minio / local file system
+
+.. ipython:: python
+    :okexcept:
+    :verbatim:
+
+    minio_client.upload_file(remote_file_path="/iftbigdata/test/file.csv", local_file_path="/my_file/path/to/file.csv")
+    minio_client.upload_file(local_file_path="/my_file/path/to/file.csv", remote_file_path="/iftbigdata/test/file.csv")

--- a/ift_global/connectors/filesystem_registry.py
+++ b/ift_global/connectors/filesystem_registry.py
@@ -105,6 +105,31 @@ class FileSystemRepository(ABC):
         pass
 
     @abstractmethod
+    def upload_file(self, remote_file_path, local_file_path):
+        """
+        Upload file to Minio.
+
+        :param remote_file_path: The path to the file to upload
+        :type file_path: str
+        :param local_file_path: The path on the local file system for the file to upload
+        :type file_path: str
+        """
+        pass
+
+    @abstractmethod
+    def download_file(self, remote_file_path, local_file_path):
+        """
+        Download file to Minio.
+
+        :param remote_file_path: The path to the file to download
+        :type file_path: str
+        :param local_file_path: The path on the local file system where the file will be downloaded
+        :type file_path: str
+        """
+        pass
+
+
+    @abstractmethod
     def write_file(self, file_path, file_type):
         """
         Write contents to a file.

--- a/ift_global/tests/test_file_system_repo.py
+++ b/ift_global/tests/test_file_system_repo.py
@@ -1,0 +1,118 @@
+import pytest
+from ift_global.connectors.filesystem_registry import FileSystemRepository  # Replace with your actual module name
+
+
+class DummyFileSystemRepository(FileSystemRepository):
+    """
+    Dummy implementation of FileSystemRepository for testing purposes.
+    """
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def list_files(self, path: str, full_path: bool = True):
+        return ["file1.txt", "file2.txt"] if full_path else ["file1", "file2"]
+
+    def list_dirs(self, path: str, full_path: bool = False):
+        return ["dir1", "dir2"] if not full_path else [f"{path}/dir1", f"{path}/dir2"]
+
+    def dir_exists(self, path):
+        return path == "/existing_directory"
+
+    def read_file(self, file_path):
+        return "file content"
+
+    def upload_file(self, remote_file_path, local_file_path):
+        return f"Uploaded {local_file_path} to {remote_file_path}"
+
+    def download_file(self, remote_file_path, local_file_path):
+        return f"Downloaded {remote_file_path} to {local_file_path}"
+
+    def write_file(self, file_path, file_type):
+        return f"Written file at {file_path} with type {file_type}"
+
+
+def test_abstract_class_instantiation():
+    """
+    Test that instantiating FileSystemRepository directly raises a TypeError.
+    """
+    with pytest.raises(TypeError):
+        FileSystemRepository()
+
+
+def test_dummy_repository_instantiation():
+    """
+    Test that a concrete implementation of FileSystemRepository can be instantiated.
+    """
+    repo = DummyFileSystemRepository(param="test")
+    assert isinstance(repo, FileSystemRepository)
+    assert repo.kwargs["param"] == "test"
+
+
+def test_list_files():
+    """
+    Test the list_files method in the dummy repository.
+    """
+    repo = DummyFileSystemRepository()
+    files = repo.list_files("/path", full_path=True)
+    assert files == ["file1.txt", "file2.txt"]
+
+    files = repo.list_files("/path", full_path=False)
+    assert files == ["file1", "file2"]
+
+
+def test_list_dirs():
+    """
+    Test the list_dirs method in the dummy repository.
+    """
+    repo = DummyFileSystemRepository()
+    dirs = repo.list_dirs("/path", full_path=True)
+    assert dirs == ["/path/dir1", "/path/dir2"]
+
+    dirs = repo.list_dirs("/path", full_path=False)
+    assert dirs == ["dir1", "dir2"]
+
+
+def test_dir_exists():
+    """
+    Test the dir_exists method in the dummy repository.
+    """
+    repo = DummyFileSystemRepository()
+    assert repo.dir_exists("/existing_directory") is True
+    assert repo.dir_exists("/non_existing_directory") is False
+
+
+def test_read_file():
+    """
+    Test the read_file method in the dummy repository.
+    """
+    repo = DummyFileSystemRepository()
+    content = repo.read_file("/path/to/file.txt")
+    assert content == "file content"
+
+
+def test_upload_file():
+    """
+    Test the upload_file method in the dummy repository.
+    """
+    repo = DummyFileSystemRepository()
+    result = repo.upload_file("remote/path/file.txt", "/local/path/file.txt")
+    assert result == "Uploaded /local/path/file.txt to remote/path/file.txt"
+
+
+def test_download_file():
+    """
+    Test the download_file method in the dummy repository.
+    """
+    repo = DummyFileSystemRepository()
+    result = repo.download_file("remote/path/file.txt", "/local/path/file.txt")
+    assert result == "Downloaded remote/path/file.txt to /local/path/file.txt"
+
+
+def test_write_file():
+    """
+    Test the write_file method in the dummy repository.
+    """
+    repo = DummyFileSystemRepository()
+    result = repo.write_file("/path/to/file.txt", "text")
+    assert result == "Written file at /path/to/file.txt with type text"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ pydata-sphinx-theme = "^0.16.1"
 python-dotenv = "^1.0.1"
 ipython = "^8.31.0"
 avro = "^1.12.0"
+pytest-minio-mock = "^0.4.16"
 
 
 [build-system]


### PR DESCRIPTION
## What does this Merge Request do?

Adds download & upload functionalities to Minio FileSystemRepo

## Why is this Merge Request needed?

This adds a useful functionality that allows users to download and upload files from / to local file system minio

## What are the changes?

two extra methods have been added to the class `MinioFileSystemRepo`:

- `upload_file` uploads a file to minio from local file system
- `download_file` downloads file from minio to local file system

## Related issues

Closing Issue #30 

## Checklist

- [x] I have tested these changes locally
- [x] I have run `codespell` locally
- [x] I have run `ruff check --fix` auto-fix locally
- [x] I have checked the `bandit` vulnerability report from CI/CD stage and fixed any major issue
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes and the overall coverage ratio was >= prior cover-ratio

### Codecov reviewer

@codecov-ai-reviewer review

